### PR TITLE
Fix memory leaks

### DIFF
--- a/push_swap/src/alg/algorithm.c
+++ b/push_swap/src/alg/algorithm.c
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 20:57:52 by jkhasiza          #+#    #+#             */
-/*   Updated: 2024/01/17 19:19:50 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/01/27 20:56:05 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,7 +113,7 @@ int	*get_cheapest(t_number *from, t_number *to, t_bool reverse)
 	{
 		steps = get_steps_to_move((*tmp)->number, from, to, reverse);
 		if (!steps)
-			return (NULL);
+			return (free(cheapest), NULL);
 		if (calculate_cost(steps) < calculate_cost(cheapest))
 			ft_int_arrcpy(cheapest, steps, STEP_SIZE);
 		tmp = &((*tmp)->next);

--- a/push_swap/src/main.c
+++ b/push_swap/src/main.c
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 18:57:52 by jkhasiza          #+#    #+#             */
-/*   Updated: 2024/01/16 18:22:02 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/01/27 20:53:20 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,23 +15,21 @@
 
 int	main(int argc, char **argv)
 {
-	t_data	*data;
+	t_data	data;
 
 	if (argc < 2)
 		exit_for(NO_INPUT);
 	if (!validate_input(argc, argv))
 		exit_for(INVALID_INPUT);
-	data = malloc(sizeof(t_data));
-	if (!data)
+	data.stack_a = NULL;
+	data.stack_b = NULL;
+	generate_stack(&data, argc, argv);
+	if (!data.stack_a)
 		return (1);
-	data->stack_a = NULL;
-	data->stack_b = NULL;
-	generate_stack(data, argc, argv);
-	if (!validate_stack_4_duplicates(&data->stack_a))
+	if (!validate_stack_4_duplicates(&data.stack_a))
 		exit_for(INVALID_INPUT);
-	sort(data);
-	ft_stackclear(&data->stack_a);
-	ft_stackclear(&data->stack_b);
-	free(data);
+	sort(&data);
+	ft_stackclear(&data.stack_a);
+	ft_stackclear(&data.stack_b);
 	return (0);
 }

--- a/push_swap/src/utils/stack.c
+++ b/push_swap/src/utils/stack.c
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/29 21:31:21 by jkhasizada        #+#    #+#             */
-/*   Updated: 2024/01/16 17:27:30 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/01/27 20:50:06 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,11 @@ void	generate_stack(t_data *data, int argc, char **argv)
 	{
 		new_elem = ft_stacknew(ft_atoi(raw_numbers[i]));
 		if (!new_elem)
+		{
+			if (argc == 2)
+				free_numbers(data->size, raw_numbers);
 			return ;
+		}
 		ft_stackadd_back(&(data->stack_a), new_elem);
 	}
 	if (argc == 2)


### PR DESCRIPTION
I had memory leaks in the `get_cheapest` function where I didn't free steps arrays called `cheapest` when memory allocation for current steps failed.

Another issue was in stack generation and if memory allocation failed for the new element in the stack, I didn't free the `raw_numbers` array with string integers.

I owe this fix to Michal from School 42 Vienna. He helped me to fix it.